### PR TITLE
33 - Add pdflatex inside dev container configuration 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 		"vscode": {
 			"settings": {},
 			"extensions": [
+				"ms-python.flake8"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,5 +11,5 @@
 		}
 	},
 	
-	"postCreateCommand": "pip3 install -r requirements.txt"
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y make texlive-xetex && pip3 install -r requirements.txt"
 }


### PR DESCRIPTION
## Description

- Add 1pdflatex1 inside the dev container configuration so that `make all` will work for generating pdf for docs


**Issue Link**: #33 

## Testing

- `make all` and `make clean` work inside the dev container

## Type of action

- [ ] Bug fix 
- [x] New feature
- [ ] Requires a documentation update
- [ ] Others: 

## Checklist

- [x] My code style is consistent with the current project
- [x] I have done a brief review of my code
- [x] I have written readable comments
- [x] I have updated the documentation related to the changes I made
- [x] I have written reasonable tests and the updated version all passed
- [x] There should be no potential errors after the changes get merged into main

